### PR TITLE
Fuijifilm RAF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This tool will enable you to quickly find and view any image or video in your co
 - Keyboard-friendly modal with navigation and rotation (images)
 - Video preview and playback in modal using HTML5 `<video>` element
 - Video preview uses pre-transcoded files from a dedicated cache directory
+- Enhanced RAW file support including improved Fujifilm RAF extraction
 - Basic path security checks
 - Configurable webserver port via CLI
 

--- a/src/processing/raw.rs
+++ b/src/processing/raw.rs
@@ -7,26 +7,105 @@ use super::cache::{generate_cache_key, save_thumbnail_to_cache, save_full_image_
 fn find_jpegs(data: &[u8]) -> Vec<(usize, usize, usize)> {
     let mut candidates = Vec::new();
     let mut i = 0;
+    
     while i < data.len() - 1 {
         if data[i] == 0xFF && data[i + 1] == 0xD8 {
+            let start = i;
             let mut end = i + 2;
+            let mut found_end = false;
+            
+            // Look for the JPEG end marker
             while end < data.len() - 1 {
                 if data[end] == 0xFF && data[end + 1] == 0xD9 {
-                    let size = end + 2 - i;
-                    if size > 50_000 {
-                        candidates.push((i, end + 2, size));
-                    }
+                    end += 2;
+                    found_end = true;
                     break;
                 }
                 end += 1;
             }
-            i = end + 2;
+            
+            // If we didn't find a proper end marker, skip this candidate
+            if !found_end {
+                i = start + 2;
+                continue;
+            }
+            
+            let size = end - start;
+            if size > 50_000 {
+                candidates.push((start, end, size));
+                log::debug!("Found JPEG candidate: {} bytes at offset {}", size, start);
+            }
+            
+            i = end;
         } else {
             i += 1;
         }
     }
+    
+    // Sort by size descending to try larger JPEGs first
+    candidates.sort_by(|a, b| b.2.cmp(&a.2));
+    log::info!("Found {} JPEG candidates", candidates.len());
+    candidates
+}
+
+// RAF-specific JPEG extraction - RAF files store preview JPEG in a specific location
+fn find_raf_jpegs(data: &[u8]) -> Vec<(usize, usize, usize)> {
+    log::debug!("Attempting RAF-specific JPEG extraction");
+    
+    let mut candidates = Vec::new();
+    
+    // RAF files have a specific structure - look for RAF signature first
+    if data.len() > 16 && &data[0..16] == b"FUJIFILMCCD-RAW " {
+        log::debug!("Confirmed RAF file format");
+        
+        // RAF files typically have JPEG preview data after the header
+        // Look for JPEG markers starting from offset 100 to skip header
+        let mut i = 100;
+        while i < data.len() - 1 {
+            if data[i] == 0xFF && data[i + 1] == 0xD8 {
+                let start = i;
+                let mut end = i + 2;
+                let mut found_end = false;
+                
+                // More aggressive search for JPEG end in RAF files
+                while end < data.len() - 1 {
+                    if data[end] == 0xFF {
+                        if end + 1 < data.len() && data[end + 1] == 0xD9 {
+                            end += 2;
+                            found_end = true;
+                            break;
+                        }
+                        // Skip over other FF markers
+                        if end + 1 < data.len() && (data[end + 1] >= 0xE0 && data[end + 1] <= 0xEF) {
+                            // Application-specific marker, skip length
+                            if end + 3 < data.len() {
+                                let marker_len = ((data[end + 2] as u16) << 8) | (data[end + 3] as u16);
+                                end += 2 + marker_len as usize;
+                                continue;
+                            }
+                        }
+                    }
+                    end += 1;
+                }
+                
+                if found_end {
+                    let size = end - start;
+                    if size > 10_000 { // Lower threshold for RAF files
+                        candidates.push((start, end, size));
+                        log::debug!("Found RAF JPEG candidate: {} bytes at offset {}", size, start);
+                    }
+                }
+                
+                i = if found_end { end } else { start + 2 };
+            } else {
+                i += 1;
+            }
+        }
+    }
+    
     // Sort by size descending
     candidates.sort_by(|a, b| b.2.cmp(&a.2));
+    log::info!("Found {} RAF-specific JPEG candidates", candidates.len());
     candidates
 }
 
@@ -46,19 +125,53 @@ pub fn convert_raw_to_rgb_jpeg(
         })?;
     log::debug!("Successfully read RAW file, size: {} bytes", file_data.len());
 
-    let candidates = find_jpegs(&file_data);
+    // Check if this is a RAF file and try RAF-specific extraction first
+    let is_raf = file_path.to_lowercase().ends_with(".raf");
+    let candidates = if is_raf {
+        log::info!("Detected RAF file, trying RAF-specific extraction first");
+        let raf_candidates = find_raf_jpegs(&file_data);
+        if !raf_candidates.is_empty() {
+            raf_candidates
+        } else {
+            log::warn!("RAF-specific extraction found no candidates, falling back to generic method");
+            find_jpegs(&file_data)
+        }
+    } else {
+        find_jpegs(&file_data)
+    };
+    
     if candidates.is_empty() {
         log::error!("No suitable embedded JPEG found in RAW file {}", file_path);
         return Err(format!("No JPEG found in RAW file {}", file_path));
     }
+
     for (idx, (start, end, size)) in candidates.iter().enumerate() {
         log::info!("Trying embedded JPEG candidate #{}: {} bytes at offset {}", idx + 1, size, start);
         let jpeg_data = &file_data[*start..*end];
+        
+        // Validate JPEG header more thoroughly
+        if jpeg_data.len() < 10 {
+            log::warn!("JPEG candidate #{} too small ({} bytes), skipping", idx + 1, jpeg_data.len());
+            continue;
+        }
+        
+        if jpeg_data[0] != 0xFF || jpeg_data[1] != 0xD8 {
+            log::warn!("JPEG candidate #{} has invalid header, skipping", idx + 1);
+            continue;
+        }
+        
         match image::load_from_memory(jpeg_data) {
             Ok(img) => {
                 let width = img.width();
                 let height = img.height();
                 log::debug!("Embedded JPEG dimensions: {}x{}", width, height);
+                
+                // Skip very small images (likely thumbnails we don't want)
+                if width < 200 || height < 200 {
+                    log::debug!("JPEG candidate #{} too small ({}x{}), trying next", idx + 1, width, height);
+                    continue;
+                }
+                
                 let scaled_img = if width > max_dimension || height > max_dimension {
                     log::debug!("Large embedded JPEG ({}x{}), using progressive scaling to {}", width, height, max_dimension);
                     let intermediate = img.resize(800, 800, image::imageops::FilterType::Triangle);
@@ -67,6 +180,7 @@ pub fn convert_raw_to_rgb_jpeg(
                     log::debug!("Small embedded JPEG ({}x{}), direct scaling to {}", width, height, max_dimension);
                     img.resize(max_dimension, max_dimension, image::imageops::FilterType::CatmullRom)
                 };
+                
                 log::trace!("Image scaling completed");
                 let mut jpeg_bytes = Vec::new();
                 scaled_img.write_with_encoder(
@@ -75,6 +189,7 @@ pub fn convert_raw_to_rgb_jpeg(
                     log::error!("Failed to encode processed RAW as JPEG for {}: {}", file_path, e);
                     format!("Failed to encode JPEG: {}", e)
                 })?;
+                
                 log::debug!("Successfully encoded RAW result as JPEG, size: {} bytes, quality: {}", jpeg_bytes.len(), jpeg_quality);
                 if let (Some(key), Some(save_fn)) = (cache_key, save_to_cache) {
                     match save_fn(key, &jpeg_bytes) {
@@ -91,6 +206,7 @@ pub fn convert_raw_to_rgb_jpeg(
             }
         }
     }
+    
     log::error!("All embedded JPEG candidates failed to decode in RAW file {}", file_path);
     Err(format!("No valid embedded JPEG could be decoded in {}", file_path))
 }


### PR DESCRIPTION
The key improvements made:

1. RAF-specific JPEG extraction: Added find_raf_jpegs() function that understands RAF file structure and looks for JPEGs after the RAF header.

2. Better JPEG validation: Enhanced JPEG detection with proper header validation and size checks to avoid corrupted data.

3. Improved search strategy: For RAF files, try RAF-specific extraction first, then fall back to generic method if needed.

4. More robust JPEG parsing: Better handling of JPEG markers and end-of-image detection, especially for RAF files which may have different embedded JPEG structures.

5. Size filtering: Skip very small embedded images that are likely thumbnails rather than the main preview image.